### PR TITLE
Fix contiguous DFS priority for GFA walks

### DIFF
--- a/pantree/graph.py
+++ b/pantree/graph.py
@@ -191,6 +191,7 @@ class PangenomeGraph(nx.DiGraph):
             if line.sample_name in priority_dict:
                 G.haplo_priorities[line.hap_name] = priority_dict[line.sample_name]
                 G.update_haplotype_positions(line)
+                G.update_haplotype_edge_positions(line)
 
             if return_walks:
                 assert G.walks is not None
@@ -210,7 +211,7 @@ class PangenomeGraph(nx.DiGraph):
 
         G.add_terminal_nodes(walk_start_nodes=walk_start_nodes, walk_end_nodes=walk_end_nodes)
         logger.info("Computing reference tree")
-        G.compute_reference_tree(dfs_method, haplo_priorities=priority_dict)
+        G.compute_reference_tree(dfs_method, haplo_priorities=G.haplo_priorities)
 
         logger.info("Computing branch points")
         G.annotate_branch_points()
@@ -593,10 +594,8 @@ class PangenomeGraph(nx.DiGraph):
 
     def update_haplotype_positions(self, line: GFAWalkLine) -> None:
         """
-        For each edge (u->v) in the walks, store:
-        primary_edge_pos = ((hap_id, contig_name, walk_id), position_bp)
-        Keep only the tuple from the highest-priority hap (smaller hap_rank wins).
-        position_bp is the cumulative bp offset at the START of (u->v) within that walk.
+        For each node in the walk, store the cumulative bp offset after traversing
+        that node under the full haplotype name.
         """
 
         walk = line.walk
@@ -607,6 +606,21 @@ class PangenomeGraph(nx.DiGraph):
             offset += len(self.nodes[u]['sequence'])
             self.nodes[u][hap_name] = offset
             self.nodes[node_complement(u)][hap_name] = offset
+
+    def update_haplotype_edge_positions(self, line: GFAWalkLine) -> None:
+        """
+        Mark each traversed walk edge with the full haplotype name.
+
+        The stored value is the cumulative bp offset after traversing the source
+        node, i.e. the position at the start of the transition.
+        """
+        hap_name = line.hap_name
+        offset = line.contig_start
+
+        for u, v in zip(line.walk[:-1], line.walk[1:]):
+            offset += len(self.nodes[u]['sequence'])
+            self.edges[u, v][hap_name] = offset
+            self.edges[node_complement(v), node_complement(u)][hap_name] = offset
 
     def compute_edge_weights(self, walks: list[list[str]]):
         """

--- a/tests/data/contiguous_priority.gfa
+++ b/tests/data/contiguous_priority.gfa
@@ -1,0 +1,14 @@
+H	VN:Z:1.1	RS:Z:ref
+S	1	A
+S	2	C
+S	3	G
+S	4	T
+S	5	A
+L	1	+	4	+	0M
+L	1	+	2	+	0M
+L	2	+	5	+	0M
+L	1	+	3	+	0M
+L	3	+	5	+	0M
+W	ref	0	0	0	2	>1>4
+W	sample1	1	0	0	3	>1>2>5
+W	sample2	1	0	0	3	>1>3>5

--- a/tests/test_graph_operations.py
+++ b/tests/test_graph_operations.py
@@ -108,8 +108,7 @@ class GraphOperationsTestBase:
         self.assertIsNotNone(G_max_weight.reference_tree)
         self.assertGreater(G_max_weight.reference_tree.number_of_edges(), 0)
 
-        # Test that the max_weight method works (it's the only one compatible with standard GFA files)
-        # The contiguous method requires haplotype labels which aren't present in standard GFA files
+        # Test that the max_weight method still works on the same GFA.
         G_again = PangenomeGraph.from_gfa_line_by_line(gfa_file, ref_name='ref', dfs_method=dfs_methods['max_weight'])
         self.assertIsNotNone(G_again.reference_tree)
         self.assertGreater(G_again.reference_tree.number_of_edges(), 0)
@@ -147,6 +146,68 @@ class GraphOperationsTestBase:
         # Reference path should still be correctly identified
         self.assertIsNotNone(G_contiguous.reference_path)
         self.assertGreater(len(G_contiguous.reference_path), 0)
+
+    def test_gfa_loader_adds_haplotype_labels_to_edges(self):
+        """Prioritized GFA walks annotate traversed edges with full haplotype labels."""
+        test_dir = os.path.dirname(__file__)
+        gfa_file = os.path.join(test_dir, "data", "contiguous_priority.gfa")
+
+        G = PangenomeGraph.from_gfa_line_by_line(
+            gfa_file,
+            ref_name='ref',
+            dfs_method=dfs_methods['contiguous'],
+            priority_dict={
+                'ref': 0,
+                'sample1': 1,
+                'sample2': 2,
+            }
+        )
+
+        self.assertIn('sample1#1#0', G.edges['1_+', '2_+'])
+        self.assertIn('sample1#1#0', G.edges['5_-', '2_-'])
+        self.assertIn('sample2#1#0', G.edges['1_+', '3_+'])
+        self.assertIn('sample2#1#0', G.edges['5_-', '3_-'])
+        self.assertIn('sample1#1#0', G.haplo_priorities)
+        self.assertNotIn('sample1', G.haplo_priorities)
+
+    def test_contiguous_priority_samples_change_gfa_loaded_tree(self):
+        """Swapping sample priorities changes the contiguous DFS tree on a loaded GFA."""
+        test_dir = os.path.dirname(__file__)
+        gfa_file = os.path.join(test_dir, "data", "contiguous_priority.gfa")
+
+        G_sample1_first = PangenomeGraph.from_gfa_line_by_line(
+            gfa_file,
+            ref_name='ref',
+            dfs_method=dfs_methods['contiguous'],
+            priority_dict={
+                'ref': 0,
+                'sample1': 1,
+                'sample2': 2,
+            }
+        )
+        G_sample2_first = PangenomeGraph.from_gfa_line_by_line(
+            gfa_file,
+            ref_name='ref',
+            dfs_method=dfs_methods['contiguous'],
+            priority_dict={
+                'ref': 0,
+                'sample2': 1,
+                'sample1': 2,
+            }
+        )
+
+        self.assertIn(('1_+', '2_+'), G_sample1_first.reference_tree.edges())
+        self.assertIn(('2_+', '5_+'), G_sample1_first.reference_tree.edges())
+        self.assertNotIn(('3_+', '5_+'), G_sample1_first.reference_tree.edges())
+
+        self.assertIn(('1_+', '3_+'), G_sample2_first.reference_tree.edges())
+        self.assertIn(('3_+', '5_+'), G_sample2_first.reference_tree.edges())
+        self.assertNotIn(('2_+', '5_+'), G_sample2_first.reference_tree.edges())
+
+        self.assertNotEqual(
+            set(G_sample1_first.reference_tree.edges()),
+            set(G_sample2_first.reference_tree.edges()),
+        )
 
     def test_priority_dict_affects_haplotype_positions(self):
         """Test that priority_dict correctly affects which haplotype positions are stored on nodes"""


### PR DESCRIPTION
## Summary
- annotate prioritized GFA walk edges with full haplotype labels and position-like offsets
- pass expanded full-haplotype priorities into contiguous DFS reference-tree construction
- add a regression fixture proving swapped priority samples change the loaded GFA tree

## Validation
- uv run pytest tests/test_haplo_contiguous_dfs_tree.py tests/test_graph_operations.py tests/test_haplotype_positions.py -q
  - passes on the rebased PR branch: 54 passed, 1 skipped
- uv run pytest tests/test_genotype.py tests/test_vcf.py tests/test_vcf_writing.py -q
  - fails on clean origin/main with the same genotype/VCF API test failures, before this PR's diff is applied

## Review
- Fresh-context correctness review: no blockers
- Fresh-context regression/test coverage review: no blockers