### PR TITLE
Fix BGZF VCF compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uv run pantree <gfa_file> <vcf_file> [options]
 - `--priority-samples TEXT`: Comma-separated list of sample names.
 - `--no-missingness`: Skip missingness computation for genotypes (see below)
 
-To output a bgzipped VCF, use a `.vcf.gz` extension for the output file. 
+To output a BGZF-compressed VCF, use a `.vcf.gz` extension for the output file.
 
 The `--dfs-method=contiguous` option creates a reference tree whose branches follow individual haplotypes as long as they can. They switch to a new haplotype when the current haplotype ends, or when the next node on the current haplotype is already in the reference tree. This behavior only applies to haplotypes belonging to the `--priority-samples` list. When switching to a new haplotype, these same samples are prioritized, in the order that they are specified. Additionally, 'haplotype positions' are computed for haplotypes belonging to samples in this list: if that haplotype visits the branch point of some haplotype, then the position of that branch point is used to compute the haplotype position of that variant edge. This follows the same rule as the ordinary `POS` field, which is that the position of the variant is the position of the first base of the `REF` and `ALT` alleles; ordinarily this is the first base after the end of the branch point node, but for on-reference indels, one base is prepended to both alleles to make them non-empty, and accordingly the position is decremented by one.
 
@@ -57,6 +57,8 @@ You can take a `.vcf` produced by `pantree` and produce a single-haplotype `.vcf
 ```bash
 pantree consolidate <vcf_file> <sample_name> <haplotype_number> <output_path>
 ```
+
+The input VCF may be uncompressed (`.vcf`) or BGZF/gzip-compressed (`.vcf.gz`).
 
 ### `simplify` subcommand
 

--- a/pantree/genotype.py
+++ b/pantree/genotype.py
@@ -155,6 +155,27 @@ class Genotype:
         return gt, cr, ca
 
     @staticmethod
+    def _ref_edge_for_index(graph: "PangenomeGraph", edge_idx: int) -> tuple[str, str] | None:
+        for u, v, data in graph.edges(data=True):
+            if data['is_in_tree'] and int(data['index']) == edge_idx:
+                return u, v
+        return None
+
+    @staticmethod
+    def _check_extra_ref_edges(
+        graph: "PangenomeGraph",
+        genotype: "Genotype",
+        expected_ref_indices: set[int],
+        errors: list[str],
+    ) -> None:
+        for edge_idx in range(genotype.num_edges):
+            if edge_idx in expected_ref_indices or genotype.get_ref_count(edge_idx) == 0:
+                continue
+            edge = Genotype._ref_edge_for_index(graph, edge_idx)
+            edge_label = edge if edge is not None else f"index {edge_idx}"
+            errors.append(f"Genotype has ref edge {edge_label} not traversed by any walk")
+
+    @staticmethod
     def verify_genotype_matches_walk(
         graph: "PangenomeGraph",
         walk: list[str],
@@ -197,12 +218,16 @@ class Genotype:
                 expected_alt[e] = expected_alt.get(e, 0) + 1
         
         # Compare expected vs actual ref counts
+        expected_ref_indices = set()
         for edge, expected_count in expected_ref.items():
-            actual_count = get_from_biedge_dict(genotype.ref_counts, edge, 0)
+            edge_idx = int(graph.edges[edge]['index'])
+            expected_ref_indices.add(edge_idx)
+            actual_count = genotype.get_ref_count(edge_idx)
             if actual_count < expected_count:
                 errors.append(
                     f"Ref edge {edge}: expected count >= {expected_count}, got {actual_count}"
                 )
+        Genotype._check_extra_ref_edges(graph, genotype, expected_ref_indices, errors)
         
         # Compare expected vs actual alt counts
         for edge, expected_count in expected_alt.items():
@@ -255,12 +280,16 @@ class Genotype:
                     expected_alt[e] = expected_alt.get(e, 0) + 1
         
         # Compare expected vs actual ref counts
+        expected_ref_indices = set()
         for edge, expected_count in expected_ref.items():
-            actual_count = get_from_biedge_dict(genotype.ref_counts, edge, 0)
+            edge_idx = int(graph.edges[edge]['index'])
+            expected_ref_indices.add(edge_idx)
+            actual_count = genotype.get_ref_count(edge_idx)
             if actual_count != expected_count:
                 errors.append(
                     f"Ref edge {edge}: expected count {expected_count}, got {actual_count}"
                 )
+        Genotype._check_extra_ref_edges(graph, genotype, expected_ref_indices, errors)
         
         # Compare expected vs actual alt counts
         for edge, expected_count in expected_alt.items():
@@ -269,11 +298,6 @@ class Genotype:
                 errors.append(
                     f"Alt edge {edge}: expected count {expected_count}, got {actual_count}"
                 )
-        
-        # Check for extra edges in genotype that weren't in walks
-        for edge in genotype.ref_counts:
-            if edge not in expected_ref and edge_complement(edge) not in expected_ref:
-                errors.append(f"Genotype has ref edge {edge} not traversed by any walk")
         
         for edge in genotype.alt_counts:
             if edge not in expected_alt and edge_complement(edge) not in expected_alt:

--- a/pantree/read_vcf.py
+++ b/pantree/read_vcf.py
@@ -1,12 +1,14 @@
 import polars as pl
 import re
 
+from .vcf_io import open_vcf_text_for_read
+
 def read_vcf_to_lazyframe(vcf_path: str) -> pl.LazyFrame:
     # Parse header to extract INFO field IDs and FORMAT fields
     info_fields = []
     format_fields = []
     sample_names = []
-    with open(vcf_path, 'r') as f:
+    with open_vcf_text_for_read(vcf_path) as f:
         for line in f:
             if line.startswith('##INFO='):
                 match = re.search(r'ID=([^,]+)', line)

--- a/pantree/vcf.py
+++ b/pantree/vcf.py
@@ -11,6 +11,7 @@ from .utils import (
     node_recover,
     get_from_biedge_dict,
 )
+from .vcf_io import open_vcf_text_for_write
 
 if TYPE_CHECKING:
     from .graph import PangenomeGraph
@@ -241,6 +242,19 @@ class _VariantRecord:
         ]
         fields.extend(self.genotype_records)
         return '\t'.join(fields) + '\n'
+
+    def sort_key(self) -> tuple[str, int, int, str]:
+        """Sort by VCF coordinates while preserving graph-order ties with UIDX."""
+        uidx = -1
+        for info_field in self.info.split(';'):
+            key, _, value = info_field.partition('=')
+            if key == 'UIDX':
+                try:
+                    uidx = int(value)
+                except ValueError:
+                    uidx = -1
+                break
+        return self.chr_name, int(self.vcf_position), uidx, self.variant_id
 
 
 @dataclass
@@ -492,7 +506,7 @@ def write_vcf_from_graph(
 
     :param graph: PangenomeGraph instance
     :param gfa_path: the .gfa file, from which walks are read, or None to skip writing genotypes
-    :param vcf_filename: the output vcf file path (use .vcf.gz extension for bgzipped output)
+    :param vcf_filename: the output vcf file path (use .vcf.gz extension for BGZF output)
     :param chr_name: the chromosome name in the first column of output vcf file
     :param logger: Logger instance for logging actions
     :param exclude_terminus: whether to exclude terminus nodes
@@ -521,60 +535,52 @@ def write_vcf_from_graph(
 
     logger.info(f"Writing vcf: {vcf_filename}")
 
-    # Autodetect bgzip from .vcf.gz extension
-    if vcf_filename.endswith('.vcf.gz') or vcf_filename.endswith('.gz'):
-        import gzip
-        file_handle = gzip.open(vcf_filename, 'wt')
-    else:
-        file_handle = open(vcf_filename, 'w')
+    vcf_records = []
+    for u, v in graph.sorted_variant_edges(exclude_terminus=exclude_terminus):
+        reference_edge = reference_edges[(u, v)]
 
-    try:
-        file_handle.write(vcf_header)
+        if graph.direction(u) == -1 and graph.direction(v) == -1:
+            u, v = edge_complement((u, v))
+        edge = (u, v)
 
-        for u, v in graph.sorted_variant_edges(exclude_terminus=exclude_terminus):
-            reference_edge = reference_edges[(u, v)]
+        # Create _VariantData from graph
+        variant_info = _VariantData.from_graph(
+            graph=graph,
+            edge=edge,
+            reference_edge=reference_edge,
+            chr_name=chr_name,
+            sample_to_genotype=sample_to_genotype,
+            size_threshold=size_threshold
+        )
 
-            if graph.direction(u) == -1 and graph.direction(v) == -1:
-                u, v = edge_complement((u, v))
-            edge = (u, v)
+        # Check for degenerate alleles if requested
+        if check_degenerate and variant_info.is_degenerate:
+            continue
 
-            # Create _VariantData from graph
-            variant_info = _VariantData.from_graph(
-                graph=graph,
-                edge=edge,
+        # Build genotype records for this edge if samples provided
+        if sample_to_genotype:
+            is_inversion = variant_info.edge_data.get('is_inversion', False)
+            ref_edge_idx = int(graph.edges[reference_edge]['index'])
+            genotype_records = _build_genotype_record(
+                variant_edge=edge,
                 reference_edge=reference_edge,
-                chr_name=chr_name,
+                ref_edge_idx=ref_edge_idx,
                 sample_to_genotype=sample_to_genotype,
-                size_threshold=size_threshold
+                is_inversion=is_inversion,
+                sample_order=sample_ids
             )
+        else:
+            genotype_records = []
 
-            # Check for degenerate alleles if requested
-            if check_degenerate and variant_info.is_degenerate:
-                continue
+        # Build VCF record from variant data
+        vcf_records.append(_VariantRecord.from_variant_data(
+            variant_info=variant_info,
+            edge=edge,
+            genotype_records=genotype_records,
+            info_fields=info_fields
+        ))
 
-            # Build genotype records for this edge if samples provided
-            if sample_to_genotype:
-                is_inversion = variant_info.edge_data.get('is_inversion', False)
-                ref_edge_idx = int(graph.edges[reference_edge]['index'])
-                genotype_records = _build_genotype_record(
-                    variant_edge=edge,
-                    reference_edge=reference_edge,
-                    ref_edge_idx=ref_edge_idx,
-                    sample_to_genotype=sample_to_genotype,
-                    is_inversion=is_inversion,
-                    sample_order=sample_ids
-                )
-            else:
-                genotype_records = []
-
-            # Build VCF record from variant data
-            vcf_record = _VariantRecord.from_variant_data(
-                variant_info=variant_info,
-                edge=edge,
-                genotype_records=genotype_records,
-                info_fields=info_fields
-            )
-
+    with open_vcf_text_for_write(vcf_filename) as file_handle:
+        file_handle.write(vcf_header)
+        for vcf_record in sorted(vcf_records, key=lambda record: record.sort_key()):
             file_handle.write(vcf_record.to_vcf_line())
-    finally:
-        file_handle.close()

--- a/pantree/vcf_io.py
+++ b/pantree/vcf_io.py
@@ -1,0 +1,30 @@
+import gzip
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, TextIO
+
+from Bio import bgzf
+
+
+def is_compressed_vcf_path(path: str | Path) -> bool:
+    return str(path).endswith(".gz")
+
+
+@contextmanager
+def open_vcf_text_for_read(path: str | Path) -> Iterator[TextIO]:
+    if is_compressed_vcf_path(path):
+        with gzip.open(path, "rt") as handle:
+            yield handle
+    else:
+        with open(path, "r") as handle:
+            yield handle
+
+
+@contextmanager
+def open_vcf_text_for_write(path: str | Path) -> Iterator[TextIO]:
+    if is_compressed_vcf_path(path):
+        with bgzf.open(path, "wt") as handle:
+            yield handle
+    else:
+        with open(path, "w") as handle:
+            yield handle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Reference tree-based variant identification and classification in
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "biopython>=1.85",
     "click>=8.3.0",
     "jupyter>=1.1.1",
     "matplotlib>=3.9.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools~=68.2.0
 tqdm
 jupyter
 matplotlib
+biopython>=1.85

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from pantree.cli import cli
 from click.testing import CliRunner
+import gzip
 import os
 import tempfile
 
@@ -88,3 +89,29 @@ def test_main_simple_nested():
         if os.path.exists(vcf_file):
             os.unlink(vcf_file)
 
+
+def test_cli_gfa2vcf_and_consolidate_with_bgzf_vcf(tmp_path):
+    """Test CLI can write BGZF VCF and use it as consolidate input."""
+    runner = CliRunner()
+    gfa_file = os.path.join(os.path.dirname(__file__), "data", "simple_nested.gfa")
+    vcf_file = tmp_path / "simple_nested.vcf.gz"
+    output_vcf = tmp_path / "sample2.hap0.vcf"
+
+    result = runner.invoke(
+        cli,
+        ['gfa2vcf', gfa_file, str(vcf_file), '--chr-id', 'chr1', '--ref-name', 'ref']
+    )
+
+    assert result.exit_code == 0, result.output
+    assert vcf_file.exists()
+    with gzip.open(vcf_file, 'rt') as f:
+        assert f.readline().strip() == '##fileformat=VCFv4.2'
+
+    result = runner.invoke(
+        cli,
+        ['consolidate', str(vcf_file), 'sample2', '0', str(output_vcf)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output_vcf.exists()
+    assert output_vcf.read_text().startswith('##fileformat=VCFv4.2')

--- a/tests/test_genotype.py
+++ b/tests/test_genotype.py
@@ -129,7 +129,8 @@ class TestGenotypeClass(unittest.TestCase):
         self.assertIsInstance(genotype, Genotype)
 
         # Check that it has the expected attributes
-        self.assertIsInstance(genotype.ref_counts, dict)
+        self.assertTrue(hasattr(genotype, 'ref_visited'))
+        self.assertIsInstance(genotype.ref_counts_multi, dict)
         self.assertIsInstance(genotype.alt_counts, dict)
         self.assertIsInstance(genotype.linear_coverage, list)
         self.assertEqual(genotype.exclude_terminus, True)
@@ -160,7 +161,7 @@ class TestGenotypeClass(unittest.TestCase):
         genotype2 = Genotype.genotype(self.G, walk2, exclude_terminus=True)
 
         # Store original counts
-        orig_ref_count = sum(genotype1.ref_counts.values())
+        orig_ref_count = sum(genotype1.get_ref_count(i) for i in range(genotype1.num_edges))
         orig_alt_count = sum(genotype1.alt_counts.values())
         orig_coverage_len = len(genotype1.linear_coverage)
 
@@ -168,7 +169,7 @@ class TestGenotypeClass(unittest.TestCase):
         genotype1.update(genotype2)
 
         # Check that counts increased
-        new_ref_count = sum(genotype1.ref_counts.values())
+        new_ref_count = sum(genotype1.get_ref_count(i) for i in range(genotype1.num_edges))
         new_alt_count = sum(genotype1.alt_counts.values())
         new_coverage_len = len(genotype1.linear_coverage)
 
@@ -211,7 +212,8 @@ class TestGenotypeClass(unittest.TestCase):
         if variant_edges:
             edge = variant_edges[0]
             reference_edge = self.G.reference_tree_edge(edge)
-            gt, cr, ca = genotype.variant_record(edge, reference_edge)
+            ref_edge_idx = int(self.G.edges[reference_edge]['index'])
+            gt, cr, ca = genotype.variant_record(edge, reference_edge, ref_edge_idx)
 
             # GT should be None or int
             self.assertTrue(gt is None or isinstance(gt, int))
@@ -369,6 +371,26 @@ class TestGenotypeMatchesWalk(unittest.TestCase):
 
         is_valid, errors = Genotype.verify_genotype_matches_walk(G, walk, genotype)
         self.assertTrue(is_valid, f"Genotype should match walk. Errors: {errors}")
+
+    def test_verify_genotype_rejects_extra_ref_edge(self):
+        """Test verification detects a reference edge not traversed by the walk."""
+        test_dir = os.path.dirname(__file__)
+        gfa_file = os.path.join(test_dir, "data", "simple_nested.gfa")
+        G = PangenomeGraph.from_gfa(gfa_file, ref_name='ref')
+
+        walk = ['1_+', '2_+', '4_+', '9_+', '10_+', '11_+']
+        genotype = Genotype.genotype(G, walk, exclude_terminus=True)
+
+        extra_edge = ('5_+', '6_+')
+        self.assertTrue(G.edges[extra_edge]['is_in_tree'])
+        extra_idx = int(G.edges[extra_edge]['index'])
+        self.assertEqual(genotype.get_ref_count(extra_idx), 0)
+
+        genotype.ref_visited[extra_idx] = True
+
+        is_valid, errors = Genotype.verify_genotype_matches_walks(G, [walk], genotype)
+        self.assertFalse(is_valid)
+        self.assertTrue(any('not traversed' in error for error in errors))
 
     def test_verify_all_haplotypes_c4a_with_inversion(self):
         """Test that all haplotypes in c4a_with_inversion_and_sequences.gfa have matching genotypes"""

--- a/tests/test_read_vcf.py
+++ b/tests/test_read_vcf.py
@@ -1,4 +1,6 @@
 import polars as pl
+import gzip
+from Bio import bgzf
 from pantree.read_vcf import read_vcf_to_lazyframe
 
 
@@ -48,3 +50,33 @@ def test_read_vcf_to_lazyframe():
     assert df['#CHROM'][0] == 'chr0'
     assert df['POS'][0] == 9
     assert df['VT'][0] == 'DUP'
+
+
+def test_read_vcf_to_lazyframe_bgzf_matches_uncompressed(tmp_path):
+    """Test compressed BGZF input parses the same as uncompressed input."""
+    vcf_path = 'tests/data/tmp5.vcf'
+    compressed_path = tmp_path / 'tmp5.vcf.gz'
+
+    with open(vcf_path, 'r') as source, bgzf.open(compressed_path, 'wt') as target:
+        target.write(source.read())
+
+    uncompressed = read_vcf_to_lazyframe(vcf_path).collect()
+    compressed = read_vcf_to_lazyframe(str(compressed_path)).collect()
+
+    assert isinstance(read_vcf_to_lazyframe(str(compressed_path)), pl.LazyFrame)
+    assert compressed.equals(uncompressed)
+
+
+def test_read_vcf_to_lazyframe_gzip_matches_uncompressed(tmp_path):
+    """Test legacy gzip-compressed input parses the same as uncompressed input."""
+    vcf_path = 'tests/data/tmp5.vcf'
+    compressed_path = tmp_path / 'tmp5.legacy.vcf.gz'
+
+    with open(vcf_path, 'rt') as source, gzip.open(compressed_path, 'wt') as target:
+        target.write(source.read())
+
+    uncompressed = read_vcf_to_lazyframe(vcf_path).collect()
+    compressed = read_vcf_to_lazyframe(str(compressed_path)).collect()
+
+    assert isinstance(read_vcf_to_lazyframe(str(compressed_path)), pl.LazyFrame)
+    assert compressed.equals(uncompressed)

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -4,8 +4,9 @@ Unit tests for VCF writing functionality
 import unittest
 import os
 import tempfile
+import gzip
+from Bio import bgzf
 from pantree.graph import PangenomeGraph
-from pantree.genotype import Genotype
 from pantree.vcf import (
     _build_genotype_record,
     _VariantRecord,
@@ -64,11 +65,14 @@ class TestGenotypeRecord(unittest.TestCase):
         
         edge = variant_edges[0]
         reference_edge = self.G.representative_edge(self.G.reference_tree_edge(edge))
+        ref_edge_idx = int(self.G.edges[reference_edge]['index'])
         is_inversion = self.G.is_inversion(edge)
         sample_order = list(sample_to_genotype.keys())
         
         # Build genotype record
-        genotype_records = _build_genotype_record(edge, reference_edge, sample_to_genotype, is_inversion, sample_order)
+        genotype_records = _build_genotype_record(
+            edge, reference_edge, ref_edge_idx, sample_to_genotype, is_inversion, sample_order
+        )
         
         # Should have one record per sample
         self.assertEqual(len(genotype_records), len(sample_to_genotype))
@@ -93,11 +97,14 @@ class TestGenotypeRecord(unittest.TestCase):
         variant_edges = list(self.G.sorted_variant_edges(exclude_terminus=True))
         edge = variant_edges[0]
         reference_edge = self.G.representative_edge(self.G.reference_tree_edge(edge))
+        ref_edge_idx = int(self.G.edges[reference_edge]['index'])
         is_inversion = self.G.is_inversion(edge)
         sample_order = list(sample_to_genotype.keys())
         
         # Build genotype record
-        genotype_records = _build_genotype_record(edge, reference_edge, sample_to_genotype, is_inversion, sample_order)
+        genotype_records = _build_genotype_record(
+            edge, reference_edge, ref_edge_idx, sample_to_genotype, is_inversion, sample_order
+        )
         
         for record in genotype_records:
             parts = record.split(':')
@@ -125,38 +132,37 @@ class TestGenotypeRecord(unittest.TestCase):
     
     def test_build_genotype_record_inversion(self):
         """Test that inversions set CR to '.'"""
-        # Create mock genotypes
-        genotype1 = Genotype(
-            ref_counts={('1_+', '2_+'): 1},
-            alt_counts={('3_+', '4_+'): 1},
-            linear_coverage=[(0, 100)],
-            exclude_terminus=True,
-            missing_variants=set()
-        )
-        
-        sample_to_genotype = {
-            'sample1': (genotype1,)
-        }
-        
-        variant_edge = ('1_+', '2_+')
-        reference_edge = ('1_+', '2_+')
-        sample_order = ['sample1']
+        sample_to_genotype = self.G.genotypes_from_gfa(self.gfa_file, exclude_terminus=True)
+        variant_edge = self.G.sorted_variant_edges(exclude_terminus=True)[0]
+        reference_edge = self.G.representative_edge(self.G.reference_tree_edge(variant_edge))
+        ref_edge_idx = int(self.G.edges[reference_edge]['index'])
+        sample_order = list(sample_to_genotype.keys())
         
         # Test with inversion
-        records = _build_genotype_record(variant_edge, reference_edge, sample_to_genotype, is_inversion=True, sample_order=sample_order)
-        self.assertEqual(len(records), 1)
+        records = _build_genotype_record(
+            variant_edge, reference_edge, ref_edge_idx, sample_to_genotype,
+            is_inversion=True, sample_order=sample_order
+        )
+        self.assertEqual(len(records), len(sample_order))
         
         # CR should be '.'
-        parts = records[0].split(':')
-        self.assertEqual(parts[1], '.')
+        for record in records:
+            parts = record.split(':')
+            self.assertTrue(all(value == '.' for value in parts[1].split(',')))
         
         # Test without inversion
-        records = _build_genotype_record(variant_edge, reference_edge, sample_to_genotype, is_inversion=False, sample_order=sample_order)
-        self.assertEqual(len(records), 1)
+        records = _build_genotype_record(
+            variant_edge, reference_edge, ref_edge_idx, sample_to_genotype,
+            is_inversion=False, sample_order=sample_order
+        )
+        self.assertEqual(len(records), len(sample_order))
         
         # CR should be numeric
-        parts = records[0].split(':')
-        self.assertTrue(parts[1].isdigit())
+        self.assertTrue(any(
+            value.isdigit()
+            for record in records
+            for value in record.split(':')[1].split(',')
+        ))
 
 
 class TestVCFRecord(unittest.TestCase):
@@ -241,11 +247,12 @@ class TestSampleOrdering(unittest.TestCase):
         
         edge = variant_edges[0]
         reference_edge = self.G.representative_edge(self.G.reference_tree_edge(edge))
+        ref_edge_idx = int(self.G.edges[reference_edge]['index'])
         is_inversion = self.G.is_inversion(edge)
         
         # Build genotype records with specific order
         genotype_records = _build_genotype_record(
-            edge, reference_edge, sample_to_genotype, is_inversion, sample_order
+            edge, reference_edge, ref_edge_idx, sample_to_genotype, is_inversion, sample_order
         )
         
         # Should have one record per sample
@@ -306,6 +313,60 @@ class TestWriteVCF(unittest.TestCase):
             
         finally:
             # Clean up
+            if os.path.exists(vcf_path):
+                os.remove(vcf_path)
+
+    def test_write_vcf_gz_is_bgzf_and_gzip_readable(self):
+        """Test that .vcf.gz output is BGZF and remains gzip-compatible."""
+        with tempfile.NamedTemporaryFile(suffix='.vcf.gz', delete=False) as f:
+            vcf_path = f.name
+
+        try:
+            import logging
+            write_vcf_from_graph(
+                graph=self.G,
+                gfa_path=self.gfa_file,
+                vcf_filename=vcf_path,
+                chr_name='chr1',
+                logger=logging.getLogger('pantree'),
+                exclude_terminus=True
+            )
+
+            with bgzf.open(vcf_path, 'rt') as f:
+                self.assertEqual(f.readline().strip(), '##fileformat=VCFv4.2')
+
+            with gzip.open(vcf_path, 'rt') as f:
+                content = f.read()
+            self.assertIn('#CHROM', content)
+            self.assertIn('chr1', content)
+
+        finally:
+            if os.path.exists(vcf_path):
+                os.remove(vcf_path)
+
+    def test_write_vcf_records_are_sorted_by_position(self):
+        """Test output records are sorted for tabix-compatible coordinate order."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.vcf', delete=False) as f:
+            vcf_path = f.name
+
+        try:
+            import logging
+            write_vcf_from_graph(
+                graph=self.G,
+                gfa_path=self.gfa_file,
+                vcf_filename=vcf_path,
+                chr_name='chr1',
+                logger=logging.getLogger('pantree'),
+                exclude_terminus=True
+            )
+
+            with open(vcf_path, 'r') as f:
+                variant_lines = [line for line in f if not line.startswith('#')]
+
+            positions = [int(line.split('\t')[1]) for line in variant_lines]
+            self.assertEqual(positions, sorted(positions))
+
+        finally:
             if os.path.exists(vcf_path):
                 os.remove(vcf_path)
     

--- a/tests/test_vcf_writing.py
+++ b/tests/test_vcf_writing.py
@@ -152,14 +152,15 @@ class TestGenotypeAggregation(unittest.TestCase):
         for walk in walks:
             genotype = Genotype.genotype(self.G, walk, exclude_terminus=True)
             
-            self.assertIsInstance(genotype.ref_counts, dict)
+            self.assertTrue(hasattr(genotype, 'ref_visited'))
+            self.assertIsInstance(genotype.ref_counts_multi, dict)
             self.assertIsInstance(genotype.alt_counts, dict)
             self.assertIsInstance(genotype.linear_coverage, list)
             
             # Should have entries if walk visits variants
             if len(self.G.variant_edges) > 0:
                 # At least one dict should have entries
-                self.assertTrue(len(genotype.ref_counts) > 0 or len(genotype.alt_counts) > 0)
+                self.assertTrue(genotype.ref_visited.any() or len(genotype.alt_counts) > 0)
     
     @unittest.skip("get_sample_vcf_info method removed during refactor")
     def test_get_sample_vcf_info(self):

--- a/tests/test_walk_variants.py
+++ b/tests/test_walk_variants.py
@@ -36,7 +36,8 @@ This is designed for variant graph traversal, where you need to:
 
 import pytest
 import polars as pl
-from pantree.walk_variants import Allele, overlap, get_walk_variants
+from pantree.graph import PangenomeGraph
+from pantree.walk_variants import Allele, overlap, get_walk_variants, process_haplotype_variants
 
 
 class TestOverlapFunction:
@@ -572,3 +573,21 @@ class TestGetWalkVariants:
         # DUP variant should have DUP status
         dup_results = [r for r in results if r.status == "DUP"]
         assert len(dup_results) == 1
+
+
+def test_process_haplotype_variants_accepts_bgzf_input(tmp_path):
+    """Test consolidate input can be a Pantree-generated BGZF VCF."""
+    gfa_path = "tests/data/simple_nested.gfa"
+    uncompressed_vcf = tmp_path / "input.vcf"
+    compressed_vcf = tmp_path / "input.vcf.gz"
+    uncompressed_output = tmp_path / "uncompressed.out.vcf"
+    compressed_output = tmp_path / "compressed.out.vcf"
+
+    graph = PangenomeGraph.from_gfa_line_by_line(gfa_path, ref_name='ref')
+    graph.write_vcf(gfa_path, str(uncompressed_vcf), chr_name='chr0')
+    graph.write_vcf(gfa_path, str(compressed_vcf), chr_name='chr0')
+
+    process_haplotype_variants(str(uncompressed_vcf), 'sample2', 0, str(uncompressed_output))
+    process_haplotype_variants(str(compressed_vcf), 'sample2', 0, str(compressed_output))
+
+    assert compressed_output.read_text() == uncompressed_output.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,47 @@ wheels = [
 ]
 
 [[package]]
+name = "biopython"
+version = "1.87"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/3e/3c6aa8b2a7e6b791a34407736db32f59657001f0446ada31db73a3e0b7d5/biopython-1.87.tar.gz", hash = "sha256:8456c803459b679a9712422e5a7fd9809f2f089bf69bb085f3b077946ac9bdbf", size = 19855264, upload-time = "2026-03-30T11:28:29.823Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/d6/a01a222dcb2a624f186907f9d7ded1d263ca6164805b0986828f8be3832c/biopython-1.87-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:35f13796188412f135acbed196bd6cfedc1257199d50b4883e289bbd96320efc", size = 2680405, upload-time = "2026-03-30T11:37:21.908Z" },
+    { url = "https://files.pythonhosted.org/packages/68/81/46d07aeac54d96e8beb20900fc8223bfae5ca5a9188d70e9f54cf704f36e/biopython-1.87-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63978e1b3ae040c52369bc1bd3f4c668171f5f1f0808798eccd74b575cce455d", size = 3194558, upload-time = "2026-03-30T11:37:27.573Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/7f5d251c133fd7f5f7dc57966b2116a15ffd1b8daf0a5144eda7419b2998/biopython-1.87-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e951f4862ffc1dccc28e1c25245059fa653d86028a88f5dfe1b7875875f3a4f", size = 3216226, upload-time = "2026-03-30T11:37:31.172Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5b/76a1a5bf4384201f2f146371f67b191b9a5000d7f3be1f962f7e829fecbd/biopython-1.87-cp310-cp310-win32.whl", hash = "sha256:86596b05f39afbc5984ee6239c93fd75f6a97fffb9a630d74b45652c24aab964", size = 2708959, upload-time = "2026-03-30T11:37:39.005Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/92/d09b783b7293567c9c662091c6dd69e9630657216deb441d1c4a9b20eeee/biopython-1.87-cp310-cp310-win_amd64.whl", hash = "sha256:efc16dd8a9312eb655fa590821495b0d8ca25d19f7b4ef4fa4da9e71d59d33e5", size = 2745184, upload-time = "2026-03-30T11:37:35.375Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/5cab8b1425d7361de75eb7395efb22f0e4a6eb899078fd008d2e748d4962/biopython-1.87-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:58e36efa7eaa8813cffe440af4824afa20cc3c21b1b179a95cc0fb15c4b83c01", size = 2680402, upload-time = "2026-03-30T11:37:42.15Z" },
+    { url = "https://files.pythonhosted.org/packages/58/09/717d55cc9d74b55fab79b283f1419b1c8785f19875e80f770737645838cc/biopython-1.87-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ccf00d15e698656796ab14ff3eb175e282da7a08eedd36a29b6cacec5a33e97f", size = 3207745, upload-time = "2026-03-30T11:37:45.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c7/06ae2e0672ef5eae35b5858355118cc265553d0ba8a23eaa1c056359683d/biopython-1.87-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bab39ec4108fb2542a9f1012db8269426fd6e86ed84ebc1b0bd11134ef443dd3", size = 3229357, upload-time = "2026-03-30T11:37:48.472Z" },
+    { url = "https://files.pythonhosted.org/packages/65/3b/77446506cec866f714e5a7c1f7613ced29762e5a6dfa6be99978dd68a273/biopython-1.87-cp311-cp311-win32.whl", hash = "sha256:126e18ad44e959a1984560562fa4f295c075ce2e610e8ddbc9ec6f52e09f70d8", size = 2708795, upload-time = "2026-03-30T11:37:53.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/76/12ac6fc6158d0e1ce92f96813dd00ae2770e2c47978c825c904c82058566/biopython-1.87-cp311-cp311-win_amd64.whl", hash = "sha256:d4ff5369ffb7a966bcf921cae6c8a6eab5070b5df1c9f2ae8c18ad40fdcb7ec5", size = 2744744, upload-time = "2026-03-30T11:37:50.974Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/18f024658c364196b7f9519674edd3233136fa19874b7ffd9e55ea0fd8e6/biopython-1.87-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:77ccc634621904d4a8fa0a43b5e0f093fa9df8c9577ed3858af648bb3528f51e", size = 2680980, upload-time = "2026-03-30T11:37:58.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/40/37c45bb4b5e345664bd970c3294349d1e35d4ad5794f808324bbef6ff9e7/biopython-1.87-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3428155c3e0abbed7aad5ff08e034d435b84dfe560c8ec58e7d43abda4b6a43", size = 3220352, upload-time = "2026-03-30T11:38:03.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/28/7898c2061966d6d62f0bb2e53cd5e1b3bb3053d2bc431f299802faca23cc/biopython-1.87-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:65ba69ef0273e983a9036c2a228142bc34266179a5f03660fc281d332d718630", size = 3246483, upload-time = "2026-03-30T11:38:07.185Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d3/a594c8443dc8979b3c051aa266aa4af2d39762c4bb2c37fe6892a19a7713/biopython-1.87-cp312-cp312-win32.whl", hash = "sha256:b077777fd2c555434bdcee58743f6f860aa80e1e005d9671913aa73823c6a773", size = 2709063, upload-time = "2026-03-30T11:38:13.53Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1a/d5884c67b20d9ae2b8d93593c971363421fd04c3dc8f5c35530c18e1d6a7/biopython-1.87-cp312-cp312-win_amd64.whl", hash = "sha256:856e3d64f1f27db493474ff84916ed8572731a525e001c7d0d8f41a0fd187000", size = 2743967, upload-time = "2026-03-30T11:38:10.739Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4b/00b8005c24f7c36d8bdffae3354194a2221716004e39029528be923adeae/biopython-1.87-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e05ef5d632c319ab3ef77705c74061190d0792b07e1f2b9eee867401b2758e7e", size = 2680946, upload-time = "2026-03-30T11:38:16.872Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/59115001469e8b3decc8362e1e6e8201acd56cafab95f4f29f4d9994fb4c/biopython-1.87-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:772539297fa16a78f38651c793f53f8c11bd18317b111982e72cf30a6e57512a", size = 3220661, upload-time = "2026-03-30T11:38:20.091Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ea/dc2840df6f676d69e898792a0cd6f1217754333ec0003ad3ed5bc7c75da7/biopython-1.87-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d221b2e08e7e89713fdbfb15c8ea6744e908d59f672cd2b6fcf9ed47910d05e", size = 3246766, upload-time = "2026-03-30T11:38:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/98/e7d0e9ed7509798286d6b043fb10a078616aff7c740ad0df506551992b09/biopython-1.87-cp313-cp313-win32.whl", hash = "sha256:fab1b12f6bc4646b7f56b4c390ecff685f02b5b29e3a0c10477195bb49fe62f8", size = 2709036, upload-time = "2026-03-30T11:38:28.822Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6e/50d9e4625d687696b3d44bba0d6ab41fe99eee74c97d5d6c5b00c20c03ad/biopython-1.87-cp313-cp313-win_amd64.whl", hash = "sha256:01ee30203bd4b2145cdfe2878499e549a7087f897a6f4d1ebd9de30790123140", size = 2743974, upload-time = "2026-03-30T11:38:26.38Z" },
+    { url = "https://files.pythonhosted.org/packages/26/3f/1ed27b0991697993c8f20bcc6b9b55a720993213e4a1aa4803b21366e11b/biopython-1.87-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db73fe16aa2b20677ac86d1997612acb0aa1a3720bc899f65d2bce5583208e1b", size = 2681105, upload-time = "2026-03-30T11:38:31.591Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7f/4d405d34d9c6fe1852527eba5dc6c92d333ef739b297df71c771da821ecf/biopython-1.87-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89ffe272517478691439a59cccd3cc2929fc8f6bfb8cbc8cc5acc103660395a7", size = 3220706, upload-time = "2026-03-30T11:38:34.572Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/26/9cade51cffba81b3c8dc314f146eb71c46c491d8092fef0f5bc4ccf3a66d/biopython-1.87-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ff28a6f31630b3c9f52903478a2ed9dd894b07c1998e40eaeefbeefac20f2d0f", size = 3246379, upload-time = "2026-03-30T11:38:38.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/59/ad1adcd0b9a600ce9fa58ecf1587a75769f05d65320f5daf315ff490fcee/biopython-1.87-cp314-cp314-win32.whl", hash = "sha256:d740c75d4bc94f9dff51719a0deda37e5e885f06ee6dfbb5e9a21bbe9de35a9c", size = 2709283, upload-time = "2026-03-30T11:38:45.886Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e3/313d4002628ffec17745336ccfbfb59d746dec5a022ebd50a9b33c3113c6/biopython-1.87-cp314-cp314-win_amd64.whl", hash = "sha256:98e397096336a49804b6aaaeac8c47ad82e3e4430862f0cde37be73037f1017e", size = 2745825, upload-time = "2026-03-30T11:38:42.285Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/70/952fb76b38c314c5c7643d55dad10c71d45d5a6c78031795d594a4a1f46f/biopython-1.87-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e4878a9b56775480154c686f81e98f6d907b44d87605bdc2f53538ccdfde9624", size = 2684826, upload-time = "2026-03-30T11:38:48.947Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fb/93e4c0fc762a10cb0d41c9807a87ad6318c4d6d21b272aa160b6394f1ceb/biopython-1.87-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6fcec2e3602ed52ced701f8f7851952383f84dbc4caeb4d202d088170e86b6d", size = 3263913, upload-time = "2026-03-30T11:38:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/63/10/5a2794c558ef6058da8413ad0ffeee2c090d250b9e5d31009faadfe84fc5/biopython-1.87-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c8da2d44a4b912c7550a051a5ff4bb72a61decc9c4b19ea92cba4c02fffb143c", size = 3283916, upload-time = "2026-03-30T11:38:54.609Z" },
+    { url = "https://files.pythonhosted.org/packages/12/cd/b18b40e9de9475cfd59f7c30dea6bab7f337758f617d3f5853b1ece8abee/biopython-1.87-cp314-cp314t-win32.whl", hash = "sha256:3670d76759c6cb53ba617f9823d3a438c1aa5415abef6addd29cb81d61d7b312", size = 2712763, upload-time = "2026-03-30T11:39:00.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/12/478812ef9c8484f96253ba8fb42b466db4f4594c3bb352a5f4318de01704/biopython-1.87-cp314-cp314t-win_amd64.whl", hash = "sha256:331c4151608a1d8406eff0d3c52a0ff1fa3e82604fc85f11c696c562919fb161", size = 2751774, upload-time = "2026-03-30T11:38:57.678Z" },
+]
+
+[[package]]
 name = "bleach"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1478,6 +1519,7 @@ name = "pantree"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "biopython" },
     { name = "click" },
     { name = "jupyter" },
     { name = "matplotlib" },
@@ -1495,6 +1537,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "biopython", specifier = ">=1.85" },
     { name = "click", specifier = ">=8.3.0" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.9.3" },


### PR DESCRIPTION
## Summary
- Write .vcf.gz output as BGZF via Biopython and centralize VCF text open behavior.
- Allow read_vcf/consolidate to consume compressed Pantree VCF input.
- Sort generated VCF records by CHROM/POS/UIDX/ID so BGZF output can be tabix-indexed, and refresh stale genotype tests/helpers needed for the current suite.

## Validation
- uv run pytest tests/test_vcf.py tests/test_read_vcf.py tests/test_walk_variants.py tests/test_cli.py -q
- uv run pytest -q
- uv run python -m py_compile pantree/vcf_io.py pantree/vcf.py pantree/read_vcf.py pantree/genotype.py
- uv run pantree gfa2vcf tests/data/simple_nested.gfa /tmp/simple_nested.vcf.gz --chr-id chr1 --ref-name ref && tabix -p vcf /tmp/simple_nested.vcf.gz