### PR TITLE
Fix node recovery for underscored segment IDs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(/**)",
+      "Edit(/notebook/**)",
+      "Write(/notebook/**)",
+      "Bash(git -C notebook *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ issues.md
 .DS_Store
 output/*
 .rules
+
+# Claude Code notebook (separate repo)
+notebook/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ tests/                # pytest suite with GFA/VCF fixtures in tests/data/
 
 GFA → parse segments/links/walks → build reference tree (DFS) → identify variant edges → compute genotypes per walk → determine missingness → extract REF/ALT alleles → write VCF
 
+## O2 Cluster
+
+- Project location: `/n/data1/hms/dbmi/oconnor/lab/luke/claude-projects/pantree`
+- Username: `ljo8`
+
 ## Notebook
 
 This project uses a separate notebook repository for analysis logs. See `notebook/INDEX.md` for a summary of past work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# Pantree
+
+Converts pangenome graphs (GFA format) into VCF files. Variants are defined as edges outside a reference tree constructed via DFS on the pangenome graph.
+
+**Paper**: Nowbandegani PS, Zhang S, Hu H, Li H, O'Connor LJ. "Defining and cataloging variants in pangenome graphs." *bioRxiv* 2025. https://doi.org/10.1101/2025.08.04.668502
+
+## Tech Stack
+
+- Python 3.10+ (target: 3.13)
+- Package manager: `uv`
+- Build system: hatchling / pyproject.toml
+- Key libs: networkx, numpy, pandas, polars, click, scipy
+
+## Commands
+
+```bash
+# Setup
+uv venv && uv sync
+
+# Run
+uv run pantree gfa2vcf <gfa_file> <vcf_file> [options]
+uv run pantree consolidate <vcf_file> <sample> <haplotype> <output>
+
+# Test
+uv run pytest
+uv run pytest --cov=pantree
+```
+
+## Project Structure
+
+```
+pantree/              # Main package
+  graph.py            # Core PangenomeGraph class (extends nx.DiGraph)
+  cli.py              # Click CLI entry point
+  dfs.py              # DFS tree construction (max_weight, haplo_contiguous)
+  vcf.py              # VCF file writing
+  gfa.py              # GFA file parsing
+  genotype.py         # Genotype counting per walk
+  walk_variants.py    # Haplotype variant consolidation
+  evaluating_functions.py  # VCF INFO field definitions
+  utils.py            # Node/edge complement helpers
+  logger.py           # Custom logging with memory tracking
+tests/                # pytest suite with GFA/VCF fixtures in tests/data/
+```
+
+## Key Concepts
+
+- **Bidirected graph**: Nodes are `id_direction` (e.g., "1_+", "2_-"). Complement flips both ID and direction.
+- **Terminal nodes**: `+_terminus_+`, `-_terminus_-`
+- **Reference tree**: Built via DFS from reference path. Edges NOT in tree = variants.
+- **Variant types**: SNP, INS, DEL, INV, DUP, MNP, COMPLEX
+- **Walks**: Sample haplotypes as node paths through the graph
+- **Edge attributes**: `index`, `weight`, `is_in_tree`, `branch_point`, `is_back_edge`
+
+## Data Flow
+
+GFA → parse segments/links/walks → build reference tree (DFS) → identify variant edges → compute genotypes per walk → determine missingness → extract REF/ALT alleles → write VCF
+
+## Notebook
+
+This project uses a separate notebook repository for analysis logs. See `notebook/INDEX.md` for a summary of past work.

--- a/pantree/utils.py
+++ b/pantree/utils.py
@@ -30,17 +30,22 @@ def _flip(s):
         raise ValueError()
 
 def node_recover(node_id):
-    if len(node_id.split('_')) == 2:
-        node, direction = node_id.split('_')
-    else:
-        terminus, node, direction = node_id.split('_')
-        node = 'start' + node.title() if terminus == '+' else 'end' + node.title()
+    try:
+        node, direction = node_id.rsplit('_', 1)
+    except ValueError:
+        raise ValueError(f"Invalid node ID: {node_id}") from None
+
+    if node == '+_terminus':
+        node = 'startTerminus'
+    elif node == '-_terminus':
+        node = 'endTerminus'
+
     if direction == '+':
         return '>'+node
     elif direction == '-':
         return '<'+node
     else:
-        raise ValueError()
+        raise ValueError(f"Invalid node direction: {direction}")
 
 def _node_convert(node_id):
     direction, node = node_id[0], node_id[1:]

--- a/tests/test_utils_extended.py
+++ b/tests/test_utils_extended.py
@@ -5,8 +5,10 @@ import unittest
 import os
 import tempfile
 from pantree.utils import (
+    _node_convert,
     sequence_complement,
     node_complement,
+    node_recover,
     edge_complement,
     walk_complement,
 )
@@ -52,6 +54,20 @@ class TestSequenceOperations(unittest.TestCase):
         # Single node walk
         single_walk = ['1_+']
         self.assertEqual(walk_complement(single_walk), ['1_-'])
+
+    def test_node_recover_preserves_underscores(self):
+        """Test recovery of oriented node IDs with underscores in segment names"""
+        self.assertEqual(_node_convert('>node_with_underscore'), 'node_with_underscore_+')
+        self.assertEqual(_node_convert('<node_with_underscore'), 'node_with_underscore_-')
+        self.assertEqual(node_recover('node_with_underscore_+'), '>node_with_underscore')
+        self.assertEqual(node_recover('node_with_underscore_-'), '<node_with_underscore')
+
+    def test_node_recover_terminus_ids(self):
+        """Test recovery of special terminus node IDs"""
+        self.assertEqual(node_recover('+_terminus_+'), '>startTerminus')
+        self.assertEqual(node_recover('+_terminus_-'), '<startTerminus')
+        self.assertEqual(node_recover('-_terminus_+'), '>endTerminus')
+        self.assertEqual(node_recover('-_terminus_-'), '<endTerminus')
 
 
 class TestGFAReading(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Recover internal node IDs by splitting only the final orientation suffix, preserving underscores in original GFA segment names.
- Preserve special terminus ID recovery behavior.
- Add regression tests for underscored segment names and terminus IDs.

## Validation
- uv run pytest tests/test_utils_extended.py -q
- uv run pytest tests/test_vcf.py tests/test_vcf_writing.py -q
- uv run pytest -q

## Review
- Fresh context review completed with no findings.
- Residual non-blocking risk: no end-to-end VCF-writing fixture yet for underscored segment IDs.