### PR TITLE
ci: pin uv to workflow Python matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
     
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --python ${{ matrix.python-version }}
     
     - name: Run tests with coverage
       run: |
-        uv run pytest --cov=graph_var --cov-report=xml --cov-report=term-missing
+        uv run --python ${{ matrix.python-version }} pytest
     
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,4 +18,4 @@ ignore:
   - "scripts/**"
   - "notebooks/**"
   - "setup.py"
-  - "graph_var/evaluating_functions.py"  # Can be excluded if not actively used
+  - "pantree/evaluating_functions.py"  # Can be excluded if not actively used


### PR DESCRIPTION
## Summary
- Pin uv dependency sync and test execution to the workflow matrix Python version.
- Remove the stale graph_var coverage override so pytest uses pyproject.toml coverage settings for pantree.
- Update the stale Codecov ignore path from graph_var to pantree.

## Validation
- uv run --python 3.13 pytest
- GitHub Actions: Tests and Coverage matrix on PR #17