### PR TITLE
Add origin metadata to simplified GFA output

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Simplify a pangenome graph by removing small variants, tips, and contracting pat
 pantree simplify input.gfa simplified.gfa --min-allele-length 1000
 ```
 
+The simplified GFA includes metadata that maps each new segment ID back to the
+input graph. The header includes `og:Z:<input.gfa>`, and each segment line
+includes `oi:J:[...]` with the original segment IDs represented by that
+simplified segment. Artificial terminal helper segments may have `oi:J:[]`
+because they do not correspond to an input graph segment:
+
+```gfa
+H	VN:Z:1.0	og:Z:input.gfa
+S	s1	ACGT	oi:J:["12","13","14"]
+S	s2		oi:J:[]
+```
+
 ## Python API Usage
 ```python
 from pantree import PangenomeGraph, Genotype

--- a/pantree/gfa.py
+++ b/pantree/gfa.py
@@ -1,8 +1,9 @@
 """
 GFA file parsing utilities.
 """
-import re
 import gzip
+import json
+import re
 from dataclasses import dataclass
 
 
@@ -69,10 +70,24 @@ class GFAWalkLine:
 class GFANodeLine:
     node_id: str
     sequence: str
+    original_ids: list[str] | None = None
 
     @classmethod
     def from_parts(cls, parts: list[str]):
-        return cls(parts[1], parts[2])
+        return cls(parts[1], parts[2], cls._parse_original_ids(parts[3:]))
+
+    @staticmethod
+    def _parse_original_ids(optional_fields: list[str]) -> list[str] | None:
+        for field in optional_fields:
+            if not field.startswith('oi:J:'):
+                continue
+            try:
+                original_ids = json.loads(field[5:])
+            except json.JSONDecodeError:
+                return None
+            if isinstance(original_ids, list):
+                return [str(original_id) for original_id in original_ids]
+        return None
 
 
 @dataclass

--- a/pantree/graph.py
+++ b/pantree/graph.py
@@ -72,7 +72,7 @@ class PangenomeGraph(nx.DiGraph):
 
     @property
     def node_attribute_names(self) -> tuple:
-        return 'direction', 'sequence', 'position', 'right_position', 'tree_position', 'on_reference_path', 'index'
+        return 'direction', 'sequence', 'position', 'right_position', 'tree_position', 'on_reference_path', 'index', 'original_ids'
 
     @property
     def vcf_attribute_names(self) -> tuple:
@@ -166,6 +166,9 @@ class PangenomeGraph(nx.DiGraph):
         logger.info("Loading S lines (nodes)")
         for line in read_gfa_line_by_line(gfa_file, line_types=['S']):
             G.add_binode(line.node_id, line.sequence)
+            if line.original_ids is not None:
+                G.nodes[f'{line.node_id}_+']['original_ids'] = list(line.original_ids)
+                G.nodes[f'{line.node_id}_-']['original_ids'] = list(reversed(line.original_ids))
         logger.info(f"Loaded {len(G.nodes) // 2} binodes")
 
         logger.info("Loading L lines (edges)")
@@ -544,14 +547,17 @@ class PangenomeGraph(nx.DiGraph):
         """
         Adds a binode to the bidirected graph, comprising a node and its complement.
         """
+        original_ids = [] if str(binode) in {'+_terminus', '-_terminus'} else [str(binode)]
         node_data = {key: 0 for key in self.node_attribute_names}
         node_data['sequence'] = seq
         node_data['direction'] = 1
+        node_data['original_ids'] = list(original_ids)
 
         self.add_node(str(binode) + '_+', **node_data)
 
         node_data['sequence'] = sequence_complement(seq)
         node_data['direction'] = -1
+        node_data['original_ids'] = list(original_ids)
 
         self.add_node(str(binode) + '_-', **node_data)
 
@@ -1192,14 +1198,23 @@ class PangenomeGraph(nx.DiGraph):
         def combine_nodes(parent: str, child: str) -> None:
             neighbors = list(simplified_graph.successors(child))
             sequence = simplified_graph.nodes[child]['sequence']
+            child_original_ids = list(simplified_graph.nodes[child].get('original_ids', []))
+            child_complement = node_complement(child)
+            child_complement_original_ids = list(simplified_graph.nodes[child_complement].get('original_ids', []))
+            parent_complement = node_complement(parent)
             simplified_graph.remove_node(child)
-            simplified_graph.remove_node(node_complement(child))
+            simplified_graph.remove_node(child_complement)
             for neighbor in neighbors:
                 simplified_graph.add_edge(parent, neighbor)
                 simplified_graph.add_edge(*edge_complement((parent, neighbor)))
             simplified_graph.nodes[parent]['sequence'] += sequence
-            simplified_graph.nodes[node_complement(parent)]['sequence'] = sequence + \
-                simplified_graph.nodes[node_complement(parent)]['sequence']
+            parent_original_ids = list(simplified_graph.nodes[parent].get('original_ids', []))
+            simplified_graph.nodes[parent]['original_ids'] = parent_original_ids + child_original_ids
+            simplified_graph.nodes[parent_complement]['sequence'] = sequence + \
+                simplified_graph.nodes[parent_complement]['sequence']
+            parent_complement_original_ids = list(simplified_graph.nodes[parent_complement].get('original_ids', []))
+            simplified_graph.nodes[parent_complement]['original_ids'] = child_complement_original_ids + \
+                parent_complement_original_ids
 
 
         node_in_degrees = {node: degree for node, degree in simplified_graph.in_degree()}

--- a/pantree/simplify_graph.py
+++ b/pantree/simplify_graph.py
@@ -80,7 +80,7 @@ def simplify_graph(gfa_file: str, output_gfa: str, ref_name: str = "GRCh38",
     if logger:
         logger.info(f"Simplified graph has {simplified_graph.number_of_nodes()} nodes and {simplified_graph.number_of_edges()} edges")
     
-    write_GFA(simplified_graph, output_gfa)
+    write_GFA(simplified_graph, output_gfa, source_gfa=gfa_file)
     
     if logger:
         logger.info(f"Wrote simplified GFA file: {output_gfa}")

--- a/pantree/write_gfa.py
+++ b/pantree/write_gfa.py
@@ -1,10 +1,25 @@
 """
 Write simplified NetworkX graph to GFA format.
 """
+import json
+
 import networkx as nx
 
 
-def write_GFA(simplified_graph: nx.DiGraph, output_path: str) -> None:
+def _optional_field(tag: str, field_type: str, value: str) -> str:
+    return f"{tag}:{field_type}:{value}"
+
+
+def _flip_orientation(orientation: str) -> str:
+    return '-' if orientation == '+' else '+'
+
+
+def _edge_complement_id(edge_id: tuple[str, str, str, str]) -> tuple[str, str, str, str]:
+    u_segment, u_orient, v_segment, v_orient = edge_id
+    return v_segment, _flip_orientation(v_orient), u_segment, _flip_orientation(u_orient)
+
+
+def write_GFA(simplified_graph: nx.DiGraph, output_path: str, source_gfa: str | None = None) -> None:
     """
     Write a simplified NetworkX graph to GFA format.
     
@@ -14,6 +29,7 @@ def write_GFA(simplified_graph: nx.DiGraph, output_path: str) -> None:
     Args:
         simplified_graph: NetworkX DiGraph with node attributes 'sequence' and 'direction'
         output_path: Path to write the GFA file
+        source_gfa: Optional path to the source GFA file
     """
     
     # Create mapping from bidirectional node pairs to unique segment IDs
@@ -38,7 +54,10 @@ def write_GFA(simplified_graph: nx.DiGraph, output_path: str) -> None:
     
     with open(output_path, 'w') as f:
         # Write header
-        f.write("H\tVN:Z:1.0\n")
+        header_fields = ["H", _optional_field("VN", "Z", "1.0")]
+        if source_gfa is not None:
+            header_fields.append(_optional_field("og", "Z", source_gfa))
+        f.write("\t".join(header_fields) + "\n")
         
         # Write S (Segment) lines
         # For each segment, use the forward orientation node to get the sequence
@@ -47,14 +66,23 @@ def write_GFA(simplified_graph: nx.DiGraph, output_path: str) -> None:
             
             if forward_node in simplified_graph.nodes():
                 sequence = simplified_graph.nodes[forward_node].get('sequence', '*')
+                origin_node = forward_node
             else:
                 # Try without orientation suffix
                 if base_name in simplified_graph.nodes():
                     sequence = simplified_graph.nodes[base_name].get('sequence', '*')
+                    origin_node = base_name
                 else:
                     sequence = '*'
+                    origin_node = None
+
+            if origin_node is not None:
+                original_ids = simplified_graph.nodes[origin_node].get('original_ids', [base_name])
+            else:
+                original_ids = [base_name]
+            origin_tag = _optional_field("oi", "J", json.dumps(original_ids, separators=(',', ':')))
             
-            f.write(f"S\t{segment_id}\t{sequence}\n")
+            f.write(f"S\t{segment_id}\t{sequence}\t{origin_tag}\n")
         
         # Write L (Link) lines
         # Track written edges to avoid duplicates
@@ -89,7 +117,7 @@ def write_GFA(simplified_graph: nx.DiGraph, output_path: str) -> None:
             # Create edge identifier to avoid duplicates
             edge_id = (u_segment, u_orient, v_segment, v_orient)
             
-            if edge_id not in written_edges:
+            if edge_id not in written_edges and _edge_complement_id(edge_id) not in written_edges:
                 written_edges.add(edge_id)
                 # GFA format: L from_segment from_orient to_segment to_orient overlap
                 # Using 0M for overlap (no overlap information)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 from pantree.cli import cli
+from pantree.graph import PangenomeGraph
 from click.testing import CliRunner
 import gzip
+import json
 import os
 import tempfile
 
@@ -115,3 +117,44 @@ def test_cli_gfa2vcf_and_consolidate_with_bgzf_vcf(tmp_path):
     assert result.exit_code == 0, result.output
     assert output_vcf.exists()
     assert output_vcf.read_text().startswith('##fileformat=VCFv4.2')
+
+
+def test_cli_simplify_writes_origin_metadata(tmp_path):
+    """Test simplify output maps simplified segments to original GFA segment IDs."""
+    runner = CliRunner()
+    gfa_file = os.path.join(os.path.dirname(__file__), "data", "simple_nested.gfa")
+    simplified_gfa = tmp_path / "simple_nested.simplified.gfa"
+
+    result = runner.invoke(
+        cli,
+        ['simplify', gfa_file, str(simplified_gfa), '--ref-name', 'ref']
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = simplified_gfa.read_text().splitlines()
+    assert lines[0].split('\t') == ['H', 'VN:Z:1.0', f'og:Z:{gfa_file}']
+
+    segment_origin_lists = []
+    origins_by_segment = {}
+    for line in lines:
+        if not line.startswith('S\t'):
+            continue
+        fields = line.split('\t')
+        origin_fields = [field for field in fields[3:] if field.startswith('oi:J:')]
+        assert len(origin_fields) == 1
+        original_ids = json.loads(origin_fields[0][5:])
+        assert all(isinstance(original_id, str) for original_id in original_ids)
+        assert all(not original_id.endswith(('_+', '_-')) for original_id in original_ids)
+        assert all('terminus' not in original_id for original_id in original_ids)
+        origins_by_segment[fields[1]] = original_ids
+        segment_origin_lists.append(original_ids)
+
+    assert segment_origin_lists
+    assert any(len(original_ids) > 1 for original_ids in segment_origin_lists)
+    assert any(len(original_ids) == 0 for original_ids in segment_origin_lists)
+
+    reread = PangenomeGraph.from_gfa_line_by_line(str(simplified_gfa), ref_name='ref')
+    assert reread.number_of_nodes() > 0
+    for segment_id, original_ids in origins_by_segment.items():
+        assert reread.nodes[f'{segment_id}_+']['original_ids'] == original_ids
+        assert reread.nodes[f'{segment_id}_-']['original_ids'] == list(reversed(original_ids))

--- a/tests/test_graph_operations.py
+++ b/tests/test_graph_operations.py
@@ -373,6 +373,30 @@ class TestGraphSimplification(unittest.TestCase):
         # Simplified graph should have fewer or equal edges
         self.assertLessEqual(simplified.number_of_edges(), original_edges)
 
+    def test_contract_paths_preserves_original_ids(self):
+        """Test path contraction records original segment IDs in sequence order."""
+        original_ids_before = {
+            node: list(data.get('original_ids', []))
+            for node, data in self.G.nodes(data=True)
+        }
+        simplified = self.G.simplify_subgraph(minimum_allele_length=1000)
+        original_id_lists = [
+            data.get('original_ids', [])
+            for node, data in simplified.nodes(data=True)
+            if node.endswith('_+') and data.get('original_ids')
+        ]
+
+        self.assertTrue(any(len(original_ids) > 1 for original_ids in original_id_lists))
+        for original_ids in original_id_lists:
+            self.assertTrue(all(not node_id.endswith(('_+', '_-')) for node_id in original_ids))
+        self.assertEqual(
+            original_ids_before,
+            {
+                node: list(data.get('original_ids', []))
+                for node, data in self.G.nodes(data=True)
+            }
+        )
+
     @unittest.skip("allele_count method removed during refactor")
     def test_allele_count(self):
         """Test that allele counts are computed"""

--- a/tests/test_haplotype_positions.py
+++ b/tests/test_haplotype_positions.py
@@ -80,7 +80,8 @@ class TestHaplotypePositions(unittest.TestCase):
             # Check if node has any haplotype position data
             # Haplotype keys are in format: sample#haplotype#contig (e.g., 'ref#0#0', 'sample1#1#0')
             # Exclude known node attributes
-            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference', 'on_reference_path'}
+            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference',
+                             'on_reference_path', 'original_ids'}
             haplotype_keys = [key for key in node_data.keys() if key not in excluded_keys and isinstance(node_data[key], (int, float))]
             if not haplotype_keys:
                 nodes_without_pos.append(node)
@@ -99,7 +100,8 @@ class TestHaplotypePositions(unittest.TestCase):
                 continue
 
             # Check for haplotype keys (exclude known node attributes)
-            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference', 'on_reference_path'}
+            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference',
+                             'on_reference_path', 'original_ids'}
             haplotype_keys = [key for key in node_data.keys() if key not in excluded_keys]
 
             for haplo_key in haplotype_keys:
@@ -127,7 +129,8 @@ class TestHaplotypePositions(unittest.TestCase):
                 continue
 
             # Check for haplotype keys (exclude known node attributes)
-            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference', 'on_reference_path'}
+            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference',
+                             'on_reference_path', 'original_ids'}
             haplotype_keys = [key for key in node_data.keys() if key not in excluded_keys]
 
             if not haplotype_keys:
@@ -180,7 +183,8 @@ class TestHaplotypePositions(unittest.TestCase):
                 continue
 
             # Haplotype keys are in format: sample#haplotype#contig (e.g., 'ref#0#0', 'sample1#1#0')
-            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference', 'on_reference_path'}
+            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference',
+                             'on_reference_path', 'original_ids'}
             haplotype_keys = [key for key in node_data.keys() if key not in excluded_keys and isinstance(node_data[key], (int, float))]
             if haplotype_keys:
                 nodes_with_positions += 1
@@ -278,7 +282,8 @@ class TestHaplotypePositionsC4A(unittest.TestCase):
 
             node_data = self.G.nodes[node]
             # Check for any haplotype position data (exclude standard node attributes)
-            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference', 'on_reference_path'}
+            excluded_keys = {'direction', 'sequence', 'position', 'right_position', 'distance_from_reference',
+                             'on_reference_path', 'original_ids'}
             haplotype_keys = [key for key in node_data.keys() if key not in excluded_keys and isinstance(node_data[key], (int, float))]
             if not haplotype_keys:
                 nodes_without_pos.append(node)


### PR DESCRIPTION
Summary:
- Track original GFA segment IDs through simplification and path contraction.
- Emit lightweight GFA metadata by default: header og:Z:<source.gfa> and per-segment oi:J:[...] JSON arrays.
- De-duplicate reverse-complement link records in simplified GFA output so the existing loader can re-read simplified graphs.
- Document the new simplify metadata and add focused CLI/simplification coverage.

Test plan:
- git diff --check
- uv run pytest tests/test_cli.py::test_cli_simplify_writes_origin_metadata tests/test_graph_operations.py::TestGraphSimplification::test_contract_paths_preserves_original_ids
- uv run pytest